### PR TITLE
5.0 init only pitfall and .NET 5 upgrades.

### DIFF
--- a/DotNetPitfalls/DotNetPitfalls.csproj
+++ b/DotNetPitfalls/DotNetPitfalls.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-        <LangVersion>8</LangVersion>
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DotNetPitfalls/InitOnlyProperties.cs
+++ b/DotNetPitfalls/InitOnlyProperties.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DotNetPitfalls
+{
+    public class InitOnlyProperties
+    {
+        private class MyAwesomeDto
+        {
+            public string Name { get; init; }
+        }
+
+        [Fact]
+        public void LooksLegit()
+        {
+            var myAwesomeInstance = new MyAwesomeDto
+            {
+                Name = "Foo"
+            };
+
+            // can't do this:
+            // myAwesomeInstance.Name = "Bar";
+            // but fear not!
+            LolWat(myAwesomeInstance);
+
+            Assert.Equal("Bar", myAwesomeInstance.Name);
+        }
+
+        private static void LolWat(MyAwesomeDto instance)
+            => typeof(MyAwesomeDto)
+                .GetProperty(nameof(MyAwesomeDto.Name))
+                .SetValue(instance, "Bar");
+    }
+}


### PR DESCRIPTION
## C#9 has introduced init-only properties.
These are properties which values can't be changed once they are initialized in the initializer block.
But it turns out that this is the compiler-only restriction and the property remains mutable as far as runtime is concerned.

_P.S. Had to update language version in order to share this thing._